### PR TITLE
Correct `iff` arguments

### DIFF
--- a/source/v1/feathers-hooks-common/index.md
+++ b/source/v1/feathers-hooks-common/index.md
@@ -882,13 +882,13 @@ Using | number of service calls
 - **Arguments**
   - `{Boolean | Promise | Function} predicate`
   - `{Array< Function >} hookFuncsTrue`
-  - `{Array< Function >} hookFuncsTrue`
+  - `{Array< Function >} hookFuncsFalse`
 
 Argument | Type | Default | Description
 ---|:---:|---|---
 `predicate` | `Boolean`, `Promise` or `Function` | | Determine if `hookFuncsTrue` or `hookFuncsFalse` should be run. If a function, `predicate` is called with the `context` as its param. It returns either a boolean or a Promise that evaluates to a boolean.
 `hookFuncsTrue` | `Array<` `Function >` | | Sync or async hook functions to run if `true`. They may include other conditional hooks.
-`hookFuncsTrue` | `Array<` `Function >` | | Sync or async hook functions to run if `false`. They may include other conditional hooks.
+`hookFuncsFalse` | `Array<` `Function >` | | Sync or async hook functions to run if `false`. They may include other conditional hooks.
 
 - **Example**
 


### PR DESCRIPTION
`iff` arguments documentation is wrong. This commit fixes it by renaming the second `hookFuncsTrue` to `hookFuncsFalse`.