### PR TITLE
Fix broken redirect in docs

### DIFF
--- a/source/v1/feathers-vuex/guide.md
+++ b/source/v1/feathers-vuex/guide.md
@@ -73,7 +73,7 @@ export default function (context) {
   const { auth } = store.state
 
   if (!auth.publicPages.includes(route.name) && !auth.payload) {
-    return redirect('login')
+    return redirect('/login')
   }
 }
 ```


### PR DESCRIPTION
The docs include a example redirect('login'), which leads in a link to http://login, if no alias is present, this PR fixes this by prepending a '/'.