### PR TITLE
Add example to the auth module docs

### DIFF
--- a/source/v1/feathers-vuex/auth-module.md
+++ b/source/v1/feathers-vuex/auth-module.md
@@ -26,6 +26,30 @@ The following actions are included in the `auth` module:
 - `logout`: use instead of `feathersClient.logout()`
 The Vuex auth store may not update if you use the feathers client version.
 
+```js
+export default {
+  // ...
+  methods: {
+    
+    login() {
+      this.$store.dispatch('auth/authenticate' {
+        email: '...',
+        password: '...'
+      })
+    }
+    
+    // ...
+    
+    logout() {
+      this.$store.dispatch('auth/logout')
+    }
+    
+  }
+  // ...
+}
+
+```
+
 
 ### Configuration
 You can provide a `userService` in the auth plugin's options to automatically populate the user upon successful login.


### PR DESCRIPTION
Updated `auth-module.md` to give an example how to use the auth module correctly, because it's not mentioned anywhere in the docs that the auth actions are namespaced within the `auth/` namespace.